### PR TITLE
Fix splitting of p4DiffOutput on windows

### DIFF
--- a/lib/atom-perforce.js
+++ b/lib/atom-perforce.js
@@ -70,7 +70,7 @@ function processDiff(p4DiffOutput) {
     var changes = [],
         change, firstChar;
 
-    p4DiffOutput.split('\n').forEach(function(line) {
+    p4DiffOutput.match(/[^\r\n]+/gm).forEach(function(line) {
         if(line.length > 1) {
             firstChar = line.substr(0, 1);
             if(!isNaN(parseInt(firstChar, 10))) {


### PR DESCRIPTION
When the p4DiffOutput uses windows line endings `\r\n` then previously each change had a trailing `\r` which messed up matching in `showDiffMarks`. Based upon http://jsperf.com/regex-split-vs-match I've swapped to using match and a regexp to do the split. I now get icons in gutter in Windows
